### PR TITLE
Add handling for badly formatted JSON

### DIFF
--- a/starsector_mod_manager/mmBase.h
+++ b/starsector_mod_manager/mmBase.h
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <regex>
 #include <memory>
+#include <filesystem>
 
 #include <wx/wx.h>
 #include <wx/dataview.h>

--- a/starsector_mod_manager/mmConfig.h
+++ b/starsector_mod_manager/mmConfig.h
@@ -3,6 +3,8 @@
 
 #include <fstream>
 #include <filesystem>
+#include <sstream>
+#include <regex>
 
 #include "json.hpp"
 
@@ -11,11 +13,15 @@ namespace fs = std::filesystem;
 
 class mmConfig : public json {
 public:
-	mmConfig();
+	mmConfig(fs::path);
 
 	bool initialise();
+	bool init_or_create(std::string key_check, json& create_with);
 
 	bool apply();
+
+private:
+	fs::path config_file;
 };
 
 #endif // !MM_CONFIG


### PR DESCRIPTION
This PR attempts to solve the issue of the program encountering JSON that is not compliant with the JSON standard.

It does so by shifting all JSON initialization and parsing into a custom subclass of JSON, which at construction time knows the path to the serialized JSON and can be actively initialized (or initialized with defaults and serialized in the case of no file existing at the given path) creating a two-step construction process. Further, all current and future interactions with serialized/deserializing JSON data must pass through this class to prevent the possibility of corrupt JSON data being passed to the JSON parser without sanitisation.