### PR TITLE
Archive support

### DIFF
--- a/starsector_mod_manager/mmBase.cpp
+++ b/starsector_mod_manager/mmBase.cpp
@@ -200,9 +200,6 @@ void mmBase::onRemoveModClick(wxCommandEvent& event) {
     }
 }
 
-void mmBase::onToggleAllClick(wxCommandEvent& event) {
-}
-
 void mmBase::onListItemDataChange(wxDataViewEvent& event) {
     int i = m_ctrl->ItemToRow(event.GetItem());
 

--- a/starsector_mod_manager/mmBase.h
+++ b/starsector_mod_manager/mmBase.h
@@ -28,12 +28,10 @@ public:
 	bool getAllMods();
 
 	void onSettings(wxCommandEvent& event);
-
 	void onListContextMenuDisplay(wxCommandEvent& event);
 	void onAddModClick(wxCommandEvent& event);
 	void onAddModFolder(wxCommandEvent& event);
 	void onRemoveModClick(wxCommandEvent& event);
-	void onToggleAllClick(wxCommandEvent& event);
 	void onListItemDataChange(wxDataViewEvent& event);
 	void onListRowSelectionChange(wxDataViewEvent& event);
 

--- a/starsector_mod_manager/mmBase.h
+++ b/starsector_mod_manager/mmBase.h
@@ -12,6 +12,8 @@
 #include <wx/dialog.h>
 #include <wx/windowptr.h>
 #include <wx/datetime.h>
+#include <wx/wfstream.h>
+#include <wx/archive.h>
 
 #include "mmSettings.h"
 #include "mmConfig.h"
@@ -26,11 +28,13 @@ public:
 	mmBase();
 
 	bool getAllMods();
+	bool decompressArchiveTo(fs::path archive, fs::path targetDir);
 
 	void onSettings(wxCommandEvent& event);
 	void onListContextMenuDisplay(wxCommandEvent& event);
 	void onAddModClick(wxCommandEvent& event);
 	void onAddModFolder(wxCommandEvent& event);
+	void onAddModArchive(wxCommandEvent& event);
 	void onRemoveModClick(wxCommandEvent& event);
 	void onListItemDataChange(wxDataViewEvent& event);
 	void onListRowSelectionChange(wxDataViewEvent& event);


### PR DESCRIPTION
This PR includes a complete, basic implementation of archive support, whereby a user can select one or more archives containing mods, and the program will automatically decompress the the archives into the mods directory and enable them if the user so wishes.